### PR TITLE
Move README to markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-About
-======
+# About
 
 This is an attempt to provide a docker composition for setting up a
 mapserver-based tileserver rendering OSM data given several styles (e.g.
 mapfiles) developped by Thomas Bonfort on basemaps
 (https://github.com/mapserver/basemaps).
 
-How to use
-===========
+## How to use
 
 Before launching the composition, some manual steps are needed, first you will
 require the mapserver-bin package (which provides a command to create indexes
@@ -38,8 +36,7 @@ http://localhost:8280/cgi-bin/mapserv?map=/map/osm-google.map
 http://localhost:8280/cgi-bin/mapserv?map=/map/osm-michelin.map
 ```
 
-Customization
-=================
+## Customization
 
 By default, a postgresql database will be created and populated with latest OSM
 rhone-alpes french region data.


### PR DESCRIPTION
Current README mixed MD and RST syntax.
